### PR TITLE
Edit Makefile and mpn_get_str_omp.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,17 +5,25 @@
 #  in /usr/{include,lib[64]}.
 ##
 
-INCDIR = /usr/local/include
-LIBDIR = /usr/local/lib
+ifdef PREFIX
+  INCDIR = ${PREFIX}/include
+  LIBDIR = ${PREFIX}/lib
+else
+  INCDIR = /usr/local/include
+  LIBDIR = /usr/local/lib
+endif
 
-CC = gcc -std=gnu99 -Wno-attributes
+CC = cc -std=gnu99 -Wno-attributes
 
 ifeq "${CFLAGS}" ""
   CFLAGS = -O2 -DBIG_SIEVE=0
 endif
 
-ifeq "${OS}" ""
+ifeq "${OS}" "Windows_NT"
+  EXE = .exe
+else
   OS = $(shell uname -s)
+  EXE =
 endif
 
 ifeq "$(strip ${OS})" "Darwin"
@@ -40,11 +48,11 @@ pi-gmp:
 	${CC} ${OPENMP} \
 	  ${CFLAGS} -DUSE_GMP pgmp-chudnovsky.c \
 	  -I${INCDIR} -L${LIBDIR} ${RPATH} \
-	  -o ../bin/pi-gmp.exe -lgmp -lm
+	  -o ../bin/pi-gmp${EXE} -lgmp -lm
 
 pi-mpir:
 	${CC} ${OPENMP} \
 	  ${CFLAGS} -DUSE_MPIR pgmp-chudnovsky.c \
 	  -I${INCDIR} -L${LIBDIR} ${RPATH} \
-	  -o ../bin/pi-mpir.exe -lmpir -lm
+	  -o ../bin/pi-mpir${EXE} -lmpir -lm
 

--- a/src/extra/gmp/mpn_get_str_omp.c
+++ b/src/extra/gmp/mpn_get_str_omp.c
@@ -49,6 +49,10 @@ see https://www.gnu.org/licenses/.  */
 # define omp_get_num_procs()   1
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+# define GCC_COMPILER 1
+#endif
+
 /* Conversion of U {up,un} to a string in base b.  Internally, we convert to
    base B = b^m, the largest power of b that fits a limb.  Basic algorithms:
 
@@ -588,16 +592,26 @@ mpn_get_str (unsigned char *str, int base, mp_ptr up, mp_size_t un)
 #endif
   }
 
+#if GCC_COMPILER
   int t_dynamic, t_nested, t_levels;
+#else
+  int t_dynamic, t_levels;
+#endif
 
 #if defined(_OPENMP)
+ #if GCC_COMPILER
   t_dynamic = omp_get_dynamic();
   t_nested  = omp_get_nested();
   t_levels  = omp_get_max_active_levels();
-
   omp_set_dynamic(0);
   omp_set_nested(1);
   omp_set_max_active_levels(3);
+ #else
+  t_dynamic = omp_get_dynamic();
+  t_levels  = omp_get_max_active_levels();
+  omp_set_dynamic(0);
+  omp_set_max_active_levels(3);
+ #endif
 #endif
 
   /* Using our precomputed powers, now in powtab[], convert our number.  */
@@ -606,9 +620,14 @@ mpn_get_str (unsigned char *str, int base, mp_ptr up, mp_size_t un)
   TMP_FREE;
 
 #if defined(_OPENMP)
+ #if GCC_COMPILER
   omp_set_max_active_levels(t_levels);
   omp_set_nested(t_nested);
   omp_set_dynamic(t_dynamic);
+ #else
+  omp_set_max_active_levels(t_levels);
+  omp_set_dynamic(t_dynamic);
+ #endif
 #endif
 
   return out_len;


### PR DESCRIPTION
I edited the Makefile for Termux but it should still be usable on other systems.
It should work with gcc or clang which ever `cc` is symlinked to.

Removed deprecated code for OpenMP nested routines.
This is also deprecated in MPIR not just GMP.

If this breaks on older compilers or OpenMP versions, I may need to force push changes to the Makefile instead.

Not sure how to do that using `ifdef` and `OMP_NESTED`.
If using `OMP_VERSION` instead, then which is the last version before nested routines were deprecated?
These I have yet to find out.